### PR TITLE
Remove bintray.com repositories from build

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+* Remove bintray repositories from build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,15 +20,6 @@ repositories {
         url = uri("https://jitpack.io")
     }
     maven {
-        url = uri("https://dl.bintray.com/kotlin/ktor")
-    }
-    maven {
-        url = uri("https://dl.bintray.com/kotlin/kotlinx")
-    }
-    maven {
-        url = uri("https://dl.bintray.com/kotlin/kotlin-js-wrappers")
-    }
-    maven {
         url = uri("https://oss.sonatype.org/content/repositories/snapshots")
     }
     maven {
@@ -37,7 +28,6 @@ repositories {
     maven {
         url = uri("https://plugins.gradle.org/m2/")
     }
-    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 kotlin {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
         mavenCentral()
         maven("https://plugins.gradle.org/m2/")
     }


### PR DESCRIPTION
Removed references to https://dl.bintray.com/ repositories.

According to https://status.bintray.com/ the project is being sunset.