### PR TITLE
Simplifier API - use partial name search

### DIFF
--- a/src/jsMain/kotlin/api/ValidatorApi.kt
+++ b/src/jsMain/kotlin/api/ValidatorApi.kt
@@ -38,6 +38,10 @@ suspend fun sendIGsRequest(): IGResponse {
     return jsonClient.get(urlString = endpoint + IG_ENDPOINT)
 }
 
+suspend fun sendIGsRequest(partialPackageName : String): IGResponse {
+    return jsonClient.get(urlString = "$endpoint$IG_ENDPOINT?name=${partialPackageName}")
+}
+
 suspend fun sendIGVersionsRequest(igPackageName : String) : IGResponse {
     return jsonClient.get(urlString = "$endpoint$IG_VERSIONS_ENDPOINT/${igPackageName}")
 }

--- a/src/jsMain/kotlin/ui/components/options/IgSelector.kt
+++ b/src/jsMain/kotlin/ui/components/options/IgSelector.kt
@@ -29,6 +29,7 @@ external interface IgSelectorProps : RProps {
     var igPackageNameList :MutableList<Pair<String, Boolean>>
     var onUpdatePackageName: (String, Boolean) -> Unit
     var selectedIgSet : MutableSet<PackageInfo>
+    var onFilterStringChange: (String) -> Unit
 }
 
 class IgSelectorState : RState {
@@ -90,6 +91,7 @@ class IgSelector : RComponent<IgSelectorProps, IgSelectorState>() {
                     }
                     multichoice = false
                     searchEnabled = true
+                    onFilterStringChange = props.onFilterStringChange
                     searchHint = "Search IGs..."
                 }
                 val versions = state.packageVersions.filter { it.first.fhirVersionMatches(props.fhirVersion)}

--- a/src/jsMain/kotlin/ui/components/options/OptionsPage.kt
+++ b/src/jsMain/kotlin/ui/components/options/OptionsPage.kt
@@ -47,7 +47,7 @@ class OptionsPage : RComponent<OptionsPageProps, OptionsPageState>() {
             val versionsResponse = sendVersionsRequest()
             setState {
                 igList = igResponse.packageInfo
-                igPackageNameList = igResponse.packageInfo.map { Pair(it.id!!, false)}.toMutableList()
+                igPackageNameList = getPackageNames(igResponse.packageInfo)
                 fhirVersionsList = versionsResponse.versions
                     .map { Pair(it, props.cliContext.getTargetVer() == it) }
                     .toMutableList()
@@ -216,6 +216,15 @@ class OptionsPage : RComponent<OptionsPageProps, OptionsPageState>() {
 
                         props.updateSelectedIgPackageInfo(newSelectedIgSet)
                     }
+                    onFilterStringChange = { partialIgName ->
+                        mainScope.launch {
+                            val igResponse = sendIGsRequest(partialIgName)
+                            setState {
+                                igList = igResponse.packageInfo
+                                igPackageNameList = getPackageNames(igResponse.packageInfo)
+                            }
+                        }
+                    }
                 }
             }
             heading {
@@ -274,6 +283,10 @@ class OptionsPage : RComponent<OptionsPageProps, OptionsPageState>() {
                 }
             }
         }
+    }
+
+    private fun getPackageNames(packageInfo : List<PackageInfo>) : MutableList<Pair<String, Boolean>> {
+        return packageInfo.map { Pair(it.id!!, false)}.toMutableList()
     }
 
     private suspend fun checkTxServer(txUrl: String): Boolean {

--- a/src/jsMain/kotlin/ui/components/options/menu/DropDownMultiChoice.kt
+++ b/src/jsMain/kotlin/ui/components/options/menu/DropDownMultiChoice.kt
@@ -36,11 +36,15 @@ external interface DropDownMultiChoiceProps : RProps {
 
     // Search field hint text (if enabled)
     var searchHint: String
+
+    // Update function to run when the currentFilterString is changed
+    var onFilterStringChange: (String) -> Unit
 }
 
 class DropDownMultiChoiceState : RState {
     var dropDownMultiChoiceDisplayed = false
     var currentFilterString = ""
+
 }
 
 /**
@@ -132,10 +136,12 @@ class DropDownMultiChoice : RComponent<DropDownMultiChoiceProps, DropDownMultiCh
                                 id = searchAreaId
                                 placeholder = props.searchHint
                                 onKeyUpFunction = {
+                                    val filterString =  (document.getElementById(searchAreaId) as HTMLInputElement).value
                                     setState {
-                                        currentFilterString =
-                                            (document.getElementById(searchAreaId) as HTMLInputElement).value
+                                        currentFilterString = filterString
+
                                     }
+                                    props.onFilterStringChange(filterString)
                                 }
                             }
                         }

--- a/src/jvmMain/kotlin/controller/ig/IgController.kt
+++ b/src/jvmMain/kotlin/controller/ig/IgController.kt
@@ -7,5 +7,7 @@ interface IgController {
 
     suspend fun listIgsFromSimplifier(): MutableList<PackageInfo>
 
+    suspend fun listIgsFromSimplifier(igPackageName : String?): MutableList<PackageInfo>
+
     suspend fun listIgVersionsFromSimplifier(igPackageName : String?): MutableList<PackageInfo>
 }

--- a/src/jvmMain/kotlin/controller/ig/IgControllerImpl.kt
+++ b/src/jvmMain/kotlin/controller/ig/IgControllerImpl.kt
@@ -27,10 +27,13 @@ class IgControllerImpl : IgController, KoinComponent {
     }
 
     override suspend fun listIgsFromSimplifier(): MutableList<PackageInfo> {
+        return listIgsFromSimplifier(null);
+    }
+    override suspend fun listIgsFromSimplifier(igPackageName : String?): MutableList<PackageInfo> {
         val packageInfoList: MutableList<PackageInfo> = mutableListOf()
 
         SIMPLIFIER_VERSIONS.forEach({
-            val packageList = packageClient.search(null, null, it, false)
+            val packageList = packageClient.search(igPackageName, null, it, false)
             packageList?.map {
                 PackageInfo(id = it.id, version = null, fhirVersion = null, url = null)
             }?.toMutableList()?.forEach({

--- a/src/jvmMain/kotlin/controller/ig/IgModule.kt
+++ b/src/jvmMain/kotlin/controller/ig/IgModule.kt
@@ -3,10 +3,13 @@ package controller.ig
 import constants.IG_ENDPOINT
 import constants.IG_VERSIONS_ENDPOINT
 import io.ktor.application.*
+import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import io.ktor.util.*
 import model.IGResponse
+import model.PackageInfo
 import org.koin.ktor.ext.inject
 
 const val NO_IGS_RETURNED = "No IGs returned from igController. List size '0'."
@@ -23,7 +26,10 @@ fun Route.igModule() {
 
         val igsFromRegistry =  igController.listIgsFromRegistry()
 
-        val igsFromSimplifier = igController.listIgsFromSimplifier()
+        val name = call.parameters["name"]
+
+
+        val igsFromSimplifier = if (name == null) {igController.listIgsFromSimplifier() } else { igController.listIgsFromSimplifier(name) }
 
         val packageInfo  = (igsFromRegistry + igsFromSimplifier).toMutableList()
 

--- a/src/jvmTest/kotlin/routing/ig/IgRoutingTest.kt
+++ b/src/jvmTest/kotlin/routing/ig/IgRoutingTest.kt
@@ -66,6 +66,25 @@ class IgRoutingTest : BaseRoutingTest() {
     }
 
     @Test
+    fun `when requesting requesting list of valid igs using a partial name, return ig response body`() = withBaseTestApplication {
+        val igResponseA = givenAListOfValidIgUrlsA()
+        val igResponseB = givenAListOfValidIgUrlsB()
+        coEvery { igController.listIgsFromRegistry() } returns igResponseA
+        coEvery { igController.listIgsFromSimplifier("dummyIgName") } returns igResponseB
+
+
+        val call = handleRequest(HttpMethod.Get, "$IG_ENDPOINT?name=dummyIgName") {
+            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+        }
+
+        with(call) {
+            assertEquals(HttpStatusCode.OK, response.status())
+            val responseBody = response.parseBody(IGResponse::class.java)
+            Assertions.assertIterableEquals(igResponseA + igResponseB, responseBody.packageInfo)
+        }
+    }
+
+    @Test
     fun `when service provides a list containing 0 items, an internal server error code is returned`() = withBaseTestApplication {
         val igResponseA = givenAnEmptyListOfIgUrls()
         val igResponseB = givenAnEmptyListOfIgUrls()


### PR DESCRIPTION
Sends the contents of the IG search field as a simplifier.net query to get a full listing of potentially matching IGs.

Fixes #83