### PR TITLE
Re-instantiate ValidationService once low memory threshold passed

### DIFF
--- a/src/jvmMain/kotlin/api/ApiInjection.kt
+++ b/src/jvmMain/kotlin/api/ApiInjection.kt
@@ -4,6 +4,8 @@ import api.terminogy.TerminologyApi
 import api.terminogy.TerminologyApiImpl
 import api.uptime.EndpointApi
 import api.uptime.EndpointApiImpl
+import controller.validation.ValidationServiceFactory
+import controller.validation.ValidationServiceFactoryImpl
 import org.hl7.fhir.utilities.npm.PackageClient
 import org.hl7.fhir.validation.cli.services.ValidationService
 import org.koin.dsl.module
@@ -13,7 +15,7 @@ object ApiInjection {
     private const val PACKAGE_CLIENT_ADDRESS = "https://packages.fhir.org"
 
     val koinBeans = module {
-        single<ValidationService> { ValidationService() }
+        single<ValidationServiceFactory> { ValidationServiceFactoryImpl() }
         single<PackageClient> { PackageClient(PACKAGE_CLIENT_ADDRESS) }
         single<TerminologyApi> { TerminologyApiImpl() }
         single<EndpointApi> { EndpointApiImpl() }

--- a/src/jvmMain/kotlin/controller/validation/ValidationControllerImpl.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationControllerImpl.kt
@@ -6,16 +6,13 @@ import org.hl7.fhir.validation.cli.model.ValidationRequest
 import org.hl7.fhir.validation.cli.services.ValidationService
 import org.koin.core.KoinComponent
 import org.koin.core.inject
-import java.io.File
-import java.io.FileInputStream
-import java.util.*
 
 class ValidationControllerImpl : ValidationController, KoinComponent {
 
-    private val validationService by inject<ValidationService>()
+    private val validationServiceFactory by inject<ValidationServiceFactory>()
 
     override suspend fun validateRequest(validationRequest: ValidationRequest): ValidationResponse {
-        return validationService.validateSources(validationRequest)
+        return validationServiceFactory.getValidationService().validateSources(validationRequest)
     }
 
     override suspend fun getValidatorVersion():String {

--- a/src/jvmMain/kotlin/controller/validation/ValidationServiceFactory.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationServiceFactory.kt
@@ -1,0 +1,8 @@
+package controller.validation
+
+import org.hl7.fhir.validation.cli.services.ValidationService
+
+interface ValidationServiceFactory {
+
+    fun  getValidationService() : ValidationService
+}

--- a/src/jvmMain/kotlin/controller/validation/ValidationServiceFactoryImpl.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationServiceFactoryImpl.kt
@@ -1,0 +1,15 @@
+package controller.validation
+
+import org.hl7.fhir.validation.cli.services.ValidationService
+
+class ValidationServiceFactoryImpl : ValidationServiceFactory {
+
+    private var validationService = ValidationService();
+
+    override fun getValidationService() : ValidationService {
+        if (java.lang.Runtime.getRuntime().freeMemory() < 2500000000) {
+            validationService = ValidationService();
+        }
+        return validationService;
+    }
+}

--- a/src/jvmTest/kotlin/controller/validation/ValidationControllerTest.kt
+++ b/src/jvmTest/kotlin/controller/validation/ValidationControllerTest.kt
@@ -7,6 +7,7 @@ import instrumentation.ValidationInstrumentation.givenAValidationResult
 import instrumentation.ValidationInstrumentation.givenAnInternalValidatorError
 import io.mockk.clearMocks
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.hl7.fhir.validation.cli.services.ValidationService
@@ -23,12 +24,13 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ValidationControllerTest : BaseControllerTest() {
     private val validationService: ValidationService = mockk()
+    private val validationServiceFactory : ValidationServiceFactory = mockk()
     private val validationController: ValidationController by lazy { ValidationControllerImpl() }
 
     init {
         startInjection(
             module {
-                single(override = true) { validationService }
+                single(override = true) { validationServiceFactory }
             }
         )
     }
@@ -36,13 +38,15 @@ class ValidationControllerTest : BaseControllerTest() {
     @BeforeEach
     override fun before() {
         super.before()
+        clearMocks(validationServiceFactory)
         clearMocks(validationService)
+        every {validationServiceFactory.getValidationService() } returns validationService;
     }
 
     @Test
     fun `test happy path, single validation outcome from ValidationService`() {
         val validationResult = givenAValidationResult(numOutcomes = 1, numMessages = 1)
-        coEvery { validationService.validateSources(any()) } returns validationResult
+        coEvery { validationServiceFactory.getValidationService().validateSources(any()) } returns validationResult
 
         runBlocking {
             val response = validationController.validateRequest(givenAValidationRequest())
@@ -53,7 +57,7 @@ class ValidationControllerTest : BaseControllerTest() {
     @Test
     fun `test happy path, multi validation outcome from ValidationService`() {
         val validationResult = givenAValidationResult(numOutcomes = 20, numMessages = 4)
-        coEvery { validationService.validateSources(any()) } returns validationResult
+        coEvery { validationServiceFactory.getValidationService().validateSources(any()) } returns validationResult
 
         runBlocking {
             val response = validationController.validateRequest(givenAValidationRequest())
@@ -64,7 +68,7 @@ class ValidationControllerTest : BaseControllerTest() {
     @Test
     fun `test internal exception from ValidationService`() {
         val internalError = givenAnInternalValidatorError()
-        coEvery { validationService.validateSources(any()) } throws internalError
+        coEvery { validationServiceFactory.getValidationService().validateSources(any()) } throws internalError
         val exception = Assertions.assertThrows(Exception::class.java) {
             runBlocking { validationController.validateRequest(givenAValidationRequest()) }
         }


### PR DESCRIPTION
This should clear memory periodically in a way that doesn't cause the server to crash and require a restart.