### PR TITLE
Document version bumping for dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack
 
 plugins {
+    // Make sure the version for multiplatform and plugin.serialization match kotlinVersion in gradle.properties
     kotlin("multiplatform") version "1.6.21"
     kotlin("plugin.serialization") version "1.6.21"
 
@@ -68,9 +69,9 @@ kotlin {
                 implementation(kotlin("stdlib-common"))
                 implementation("org.jetbrains.kotlin:kotlin-reflect:1.5.0")
                 implementation("com.fasterxml.jackson.core:jackson-databind:${property("jacksonVersion")}")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${property("serializationVersion")}")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:${property("serializationVersion")}")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:${property("serializationVersion")}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${property("kotlinxSerializationVersion")}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:${property("kotlinxSerializationVersion")}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-protobuf:${property("kotlinxSerializationVersion")}")
                 implementation("ca.uhn.hapi.fhir:org.hl7.fhir.validation:${property("fhirCoreVersion")}")
                 implementation("ca.uhn.hapi.fhir:org.hl7.fhir.utilities:${property("fhirCoreVersion")}")
             }
@@ -104,7 +105,7 @@ kotlin {
                 implementation("io.ktor:ktor-serialization-gson:${property("ktorVersion")}")
                 implementation("io.ktor:ktor-serialization-jackson:${property("ktorVersion")}")
                 implementation("io.ktor:ktor-serialization:${property("ktorVersion")}")
-                implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:${property("kotlinxVersion")}")
+                implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:${property("kotlinxHtmlVersion")}")
                 implementation("io.insert-koin:koin-ktor:${property("koinVersion")}")
                 //TODO
                 implementation("io.ktor:ktor-client-core:${property("ktorVersion")}")
@@ -147,7 +148,7 @@ kotlin {
                 implementation("io.ktor:ktor-client-content-negotiation:${property("ktorVersion")}")
                 implementation("io.ktor:ktor-client-serialization-js:${property("ktorVersion")}")
 
-                implementation("org.jetbrains.kotlinx:kotlinx-html-js:${property("kotlinxVersion")}")
+                implementation("org.jetbrains.kotlinx:kotlinx-html-js:${property("kotlinxHtmlVersion")}")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${property("kotlinxCoroutinesVersion")}")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:${property("ktorVersion")}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,18 +3,42 @@ kotlin.js.generate.executable.default=false
 
 # versions
 fhirCoreVersion=5.6.55
-jacksonVersion=2.12.6
+
 junitVersion=5.7.1
-koinVersion=3.2.1
-kotlinVersion=1.6.21
-kotlinxVersion=0.7.5
-kotlinxCoroutinesVersion=1.6.3
-ktorVersion=2.0.2
-logbackVersion=1.2.3
 mockk_version=1.10.2
 
-serializationVersion=1.3.2
-kmongoVersion=4.5.0
 tornadoFXVersion=1.7.20
 
+# IMPORTANT NOTES ON UPDATING the following kotlin related dependency versions.
+# The following dependencies are very interdependent. Misaligned dependencies can cause hard to diagnose errors at build
+# and run time.
+#
+# As a general guideline the commit histories for the following two projects can give you an idea of the correct version
+# combinations of dependencies:
+#  https://github.com/kotlin-hands-on/jvm-js-fullstack
+#  https://github.com/kotlin-hands-on/web-app-react-kotlin-js-gradle
+#
+kotlinVersion=1.6.21
+
+# Version compatibility with kotlinVersion is noted in https://github.com/Kotlin/kotlinx.html/releases
+kotlinxHtmlVersion=0.7.5
+# Version compatibility with kotlinVersion is noted in https://github.com/Kotlin/kotlinx.coroutines/releases
+kotlinxCoroutinesVersion=1.6.3
+# Version compatibility with kotlinVersion is noted in https://github.com/Kotlin/kotlinx.serialization/releases
+kotlinxSerializationVersion=1.3.2
+
+# This is the version of kotlinWrappers used for the management of things like our react wrappers.
+# See https://github.com/JetBrains/kotlin-wrappers
 kotlinWrappersVersion=0.0.1-pre.332-kotlin-1.6.21
+
+# These three versions are interrelated, sometimes in mysterious ways. kotlin-hands-on projects are a good indicator of
+# 'safe' combinations.
+ktorVersion=2.0.2
+jacksonVersion=2.12.6
+koinVersion=3.2.1
+logbackVersion=1.2.3
+kmongoVersion=4.5.0
+
+
+
+


### PR DESCRIPTION
This adds some documentation to help with the painful process of version bumping for Kotlin and Kotlin Multiplatform