### PR TITLE
Fix deserialization issue in terminology endpoint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 # versions
-fhirCoreVersion=5.6.83
+fhirCoreVersion=5.6.84
 
 junitVersion=5.7.1
 mockk_version=1.10.2

--- a/src/jvmMain/kotlin/controller/terminology/TerminologyControllerImpl.kt
+++ b/src/jvmMain/kotlin/controller/terminology/TerminologyControllerImpl.kt
@@ -10,8 +10,8 @@ class TerminologyControllerImpl : TerminologyController, KoinComponent {
     override suspend fun isTerminologyServerValid(capabilityStatement: CapabilityStatement): Boolean {
         capabilityStatement.instantiates?.forEach { canonicalType ->
             if (canonicalType != null) {
-                println("Cap statement -> ${canonicalType.valueAsString}")
-                if (canonicalType.valueAsString == TERMINOLOGY_CAP_STATEMENT) return true
+                println("Cap statement -> ${canonicalType}")
+                if (canonicalType == TERMINOLOGY_CAP_STATEMENT) return true
             }
         }
         return false

--- a/src/jvmMain/kotlin/model/CapabilityStatement.kt
+++ b/src/jvmMain/kotlin/model/CapabilityStatement.kt
@@ -2,4 +2,8 @@ package model
 
 import org.hl7.fhir.r5.model.CanonicalType
 
-data class CapabilityStatement(var instantiates: MutableList<CanonicalType?>? = mutableListOf())
+/*TODO this should be using r5.model.CanonicalType for `instantiates`, BUT canonicalType needs some kotliny intervention
+to work with fasterxml.jackson.databind because of 'Conflicting setter definitions for property "referenceElement"'.
+This probably needs JSON annotations somewhere to disambiguate.
+ */
+data class CapabilityStatement(var instantiates: MutableList<String?>? = mutableListOf())

--- a/src/jvmTest/kotlin/instrumentation/TerminologyInstrumentation.kt
+++ b/src/jvmTest/kotlin/instrumentation/TerminologyInstrumentation.kt
@@ -35,16 +35,14 @@ object TerminologyInstrumentation {
 
     fun givenAValidCapabilityStatement(): CapabilityStatement {
         val capStmt = CapabilityStatement()
-        val canonicalType = CanonicalType()
-        canonicalType.value = "http://hl7.org/fhir/CapabilityStatement/terminology-server"
+        val canonicalType = "http://hl7.org/fhir/CapabilityStatement/terminology-server"
         capStmt.instantiates?.add(canonicalType)
         return capStmt
     }
 
     fun givenAnInvalidCapabilityStatement(): CapabilityStatement {
         val capStmt = CapabilityStatement()
-        val canonicalType = CanonicalType()
-        canonicalType.value = "https://tinyurl.com/3usj3yvc"
+        val canonicalType = "https://tinyurl.com/3usj3yvc"
         capStmt.instantiates?.add(canonicalType)
         return capStmt
     }


### PR DESCRIPTION
The deserialization of the `instantiates` field of CapabilityStatement was throwing errors due to 'Conflicting setter definitions for property "referenceElement"'

This is remedied by switching to a string primitive, as `instantiates` is a Canonical URL, which is serialized as a string value.

Eventually, if the need arises for more complex verification, we could improve the Jackson deserialization, as in the code comments, but this is more work than its worth now.