### PR TITLE
Fix terminology server verification

### DIFF
--- a/src/jsMain/kotlin/ui/components/options/AddExtension.kt
+++ b/src/jsMain/kotlin/ui/components/options/AddExtension.kt
@@ -33,7 +33,7 @@ class AddExtensionState : State {
 }
 
 class AddExtension : RComponent<AddExtensionProps, AddExtensionState>() {
-    private val textInputId = "text_entry_field"
+    val textInputId = "extension_entry"
     init {
         state = AddExtensionState()
     }

--- a/src/jsMain/kotlin/ui/components/options/OptionsPage.kt
+++ b/src/jsMain/kotlin/ui/components/options/OptionsPage.kt
@@ -285,7 +285,9 @@ class OptionsPage : RComponent<OptionsPageProps, OptionsPageState>() {
                     currentEntry = props.cliContext.getTxServer()
                     explanation = props.polyglot.t("options_settings_tm_description")
                     heading = props.polyglot.t("options_settings_tm_title")
+                    textFieldId = "terminology_server_entry"
                     onSubmitEntry = { url ->
+
                         GlobalScope.async {
                             val txServerOutcome = async { checkTxServer(url) }
                             if (txServerOutcome.await()) {

--- a/src/jsMain/kotlin/ui/components/options/menu/TextFieldEntry.kt
+++ b/src/jsMain/kotlin/ui/components/options/menu/TextFieldEntry.kt
@@ -31,6 +31,7 @@ external interface TextFieldEntryProps : Props {
     var buttonLabel: String
     var errorMessage: String
     var successMessage: String
+    var textFieldId : String
 }
 
 class TextFieldEntryState : State {
@@ -39,8 +40,9 @@ class TextFieldEntryState : State {
     var validating = false
 }
 
+
 class TextFieldEntry : RComponent<TextFieldEntryProps, TextFieldEntryState>() {
-    private val textInputId = "text_entry_field"
+   //private val textInputId = "text_entry_field"
 
     override fun RBuilder.render() {
         styledDiv {
@@ -71,7 +73,7 @@ class TextFieldEntry : RComponent<TextFieldEntryProps, TextFieldEntryState>() {
                     attrs {
                         type = InputType.text
                         defaultValue = props.currentEntry
-                        id = textInputId
+                        id = props.textFieldId
                         onChangeFunction = {
                             setState {
                                 displayingError = false
@@ -98,7 +100,7 @@ class TextFieldEntry : RComponent<TextFieldEntryProps, TextFieldEntryState>() {
                             }
                             GlobalScope.launch {
                                 val result =
-                                    props.onSubmitEntry((document.getElementById(textInputId) as HTMLInputElement).value)
+                                    props.onSubmitEntry((document.getElementById(props.textFieldId) as HTMLInputElement).value)
                                         .await()
                                 if (result) {
                                     setState {
@@ -114,8 +116,6 @@ class TextFieldEntry : RComponent<TextFieldEntryProps, TextFieldEntryState>() {
                                     }
                                 }
                             }
-
-
                         }
                     }
                 }


### PR DESCRIPTION
The UI elements involved in extensions and in terminology server used the same ID, resulting in failures of terminology server verification.

This gives them unique IDs.

For testing, ensure that extensions can be added to the allowed extensions list, and that terminology server verification works correctly.