### PR TITLE
fix location of REST API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A publicly hosted instance of the Web interface for this validator is available 
 
 ## REST API
 
-**[See here](rest-api.md) for the REST API documentation.**
+**[See here](.github/workflows/rest-api.md) for the REST API documentation.**
 
 ## Building this Project
 


### PR DESCRIPTION
In README.md the link to the markdown documentaton for the REST API did not work. The markdown file is currently located in .github/workflows/.