### PR TITLE
Pre-load Package Cache on Disk

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 # versions
-fhirCoreVersion=6.2.4
+fhirCoreVersion=6.2.6-SNAPSHOT
 
 junitVersion=5.7.1
 mockk_version=1.10.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 # versions
-fhirCoreVersion=6.2.6-SNAPSHOT
+fhirCoreVersion=6.2.6
 
 junitVersion=5.7.1
 mockk_version=1.10.2

--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -10,6 +10,7 @@ import org.hl7.fhir.validation.ValidatorCli
 import org.hl7.fhir.validation.cli.utils.Params
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
+import utils.PackageCacheDownloaderRunnable
 import java.util.concurrent.TimeUnit
 
 private const val DEFAULT_ENVIRONMENT: String = "dev"
@@ -61,6 +62,13 @@ fun startServer(args: Array<String>) {
     val environment = System.getenv()["ENVIRONMENT"] ?: handleDefaultEnvironment()
     val config = extractConfig(environment, HoconApplicationConfig(ConfigFactory.load()))
 
+    val preloadCache = System.getenv()["PRELOAD_CACHE"] ?: "false"
+
+    if (preloadCache != null && preloadCache.equals("true")) {
+
+        Thread(PackageCacheDownloaderRunnable()).start();
+    }
+
     engine = embeddedServer(Jetty, host = config.host, port = config.port) {
         println("Starting instance in ${config.host}:${config.port}")
         module {
@@ -75,6 +83,7 @@ fun startServer(args: Array<String>) {
     }
 
     engine.start(wait = true)
+
 }
 
 /**

--- a/src/jvmMain/kotlin/controller/validation/ValidationControllerImpl.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationControllerImpl.kt
@@ -1,7 +1,7 @@
 package controller.validation
 
 import model.ValidationResponse
-import org.hl7.fhir.validation.cli.utils.VersionUtil
+import org.hl7.fhir.utilities.VersionUtil
 import org.hl7.fhir.validation.cli.model.ValidationRequest
 import org.hl7.fhir.validation.cli.services.ValidationService
 import org.koin.core.component.KoinComponent

--- a/src/jvmMain/kotlin/utils/PackageCacheDownloaderRunnable.kt
+++ b/src/jvmMain/kotlin/utils/PackageCacheDownloaderRunnable.kt
@@ -1,0 +1,12 @@
+package utils
+
+import org.hl7.fhir.validation.packages.PackageCacheDownloader
+
+class PackageCacheDownloaderRunnable : Runnable {
+    public override fun run() {
+        println("PackageCacheDownloader: starting pre-load of all available packages")
+        val packageCacheDownloader = PackageCacheDownloader()
+        packageCacheDownloader.visitPackages()
+        println("PackageCacheDownloader: pre-load complete.")
+    }
+}


### PR DESCRIPTION
On server start, when the PRELOAD_CACHE env variable is set to true, a thread is started that fills the package cache on the disk with all available packages.