### PR TITLE
Fix file extension case in upload tab

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 # versions
-fhirCoreVersion=6.2.8
+fhirCoreVersion=6.2.10
 
 junitVersion=5.7.1
 mockk_version=1.10.2

--- a/src/jsMain/kotlin/ui/components/tabs/uploadtab/UploadFilesComponent.kt
+++ b/src/jsMain/kotlin/ui/components/tabs/uploadtab/UploadFilesComponent.kt
@@ -60,7 +60,7 @@ class UploadFilesComponent : RComponent<UploadFilesComponentProps, State>(), Fil
     override fun onLoadComplete(event: Event, fileLoadState: FileLoadState) {
         props.onFileUpload(FileInfo(fileName = fileLoadState.file.name,
             fileContent = fileLoadState.content,
-            fileType = fileLoadState.file.extension))
+            fileType = fileLoadState.file.extension.lowercase()))
     }
 
     override fun onLoadError(fileLoadState: FileLoadState) {


### PR DESCRIPTION
File types are automatically inferred through file name extensions. If these are uppercase, FHIRFormat doesn't correctly recognize them, and the validation service does not return results.