### PR TITLE
Update core version to 6.3.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 # versions
-fhirCoreVersion=6.2.15
+fhirCoreVersion=6.3.0
 
 junitVersion=5.7.1
 mockk_version=1.10.2


### PR DESCRIPTION
Just a quick PR to bump the org.hl7.fhir.core version to the latest version `6.3.0`. Please let me know if there's anything else I can do to assist in getting an updated release out, or if this PR is just noise and the team already has a better process in place feel free to just close/ignore it. Thank you!