### PR TITLE
Log full stack trace on validator exceptions

### DIFF
--- a/src/jvmMain/kotlin/controller/validation/ValidationModule.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationModule.kt
@@ -42,7 +42,7 @@ fun Route.validationModule() {
                 try {
                     call.respond(HttpStatusCode.OK, validationController.validateRequest(request))
                 } catch (e: Exception) {
-                    logger.error(e.localizedMessage)
+                    logger.error(e.localizedMessage, e)
                     call.respond(HttpStatusCode.InternalServerError, e.localizedMessage)
                 }
             }


### PR DESCRIPTION
It can be difficult to debug the root cause of exceptions in the validator wrapper because only the exception message is returned and logged, not the whole stack trace. This PR just adds the caught exception to the logger statement so that the stack trace is logged. No changes to the response.
Addresses the most important part of #170 (and the previous PR #168 also made uncaught Errors get logged, so that's no longer a big concern either) 

I haven't been able to consistently reproduce Exceptions (the ones we've seen have been one-off or environment related), so the easiest way to test this is probably to change the method `ValidationControllerImpl.validateRequest` to just throw an exception, eg:
```kotlin
throw org.hl7.fhir.exceptions.FHIRException("test")
```

Before this PR change, this would log:
```
2024-04-09 11:57:11.033 [ktor-jetty-8082-2] INFO  ktor.application - Received Validation Request. FHIR Version: 4.0.1 IGs: [] Memory (free/max): 543476728/9663676416
2024-04-09 11:57:11.039 [ktor-jetty-8082-2] ERROR ktor.application - test
2024-04-09 11:57:11.300 [ktor-jetty-8082-4] INFO  ktor.application - 500 Internal Server Error: POST - /validate
```

With the PR change:

```
2024-04-09 11:53:14.321 [ktor-jetty-8082-2] INFO  ktor.application - Received Validation Request. FHIR Version: 4.0.1 IGs: [] Memory (free/max): 544638504/9663676416
2024-04-09 11:53:14.327 [ktor-jetty-8082-2] ERROR ktor.application - test
org.hl7.fhir.exceptions.FHIRException: test
	at controller.validation.ValidationControllerImpl.validateRequest(ValidationControllerImpl.kt:18)
	at controller.validation.ValidationModuleKt$validationModule$1.invokeSuspend(ValidationModule.kt:43)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:138)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:112)
	at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:14)
	at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:62)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
2024-04-09 11:53:14.587 [ktor-jetty-8082-4] INFO  ktor.application - 500 Internal Server Error: POST - /validate
```