### PR TITLE
Use gson for serialization/deserialization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.generate.executable.default=false
 
 # versions
-fhirCoreVersion= 6.4.2
+fhirCoreVersion= 6.4.4-SNAPSHOT
 
 junitVersion=5.7.1
 mockk_version=1.10.2

--- a/src/jvmMain/kotlin/Module.kt
+++ b/src/jvmMain/kotlin/Module.kt
@@ -1,5 +1,4 @@
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
+import io.ktor.serialization.gson.*
 import controller.debug.debugModule
 import controller.ig.igModule
 import controller.terminology.terminologyModule
@@ -85,14 +84,8 @@ fun Application.setup() {
     }
 
     install(ContentNegotiation) {
-        jackson {
-            enable(SerializationFeature.INDENT_OUTPUT)
-
-            /*
-             * Right now we need to ignore unknown fields because we take a very simplified version of many of the fhir
-             * model classes, and map them to classes across JVM/Common/JS.
-             */
-            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        gson {
+            setPrettyPrinting()
         }
     }
 


### PR DESCRIPTION
Switches content negotiation from jackson to gson.

This will require core to be updated before this can be merged, with this PR: https://github.com/hapifhir/org.hl7.fhir.core/pull/1824