### PR TITLE
Make download explicitly reference app

### DIFF
--- a/src/commonMain/resources/static-content/polyglot/de_DE.json
+++ b/src/commonMain/resources/static-content/polyglot/de_DE.json
@@ -79,7 +79,7 @@
   "footer_running_version" : "Validator Version v",
   "footer_github" : "Projekt auf Github ansehen",
   "footer_create_issue" : "Issue erstellen",
-  "footer_download_cli" : "download des neusten cli",
+  "footer_download_cli" : "download diese app als CLI-tool",
   "footer_doc" : "die Dokumentation des Validators anzeigen",
   "footer_openapi" : "die Dokumentation des OpenAPI anzeigen",
   "validation_results" : "Ergebnisse",

--- a/src/commonMain/resources/static-content/polyglot/en.json
+++ b/src/commonMain/resources/static-content/polyglot/en.json
@@ -81,7 +81,7 @@
   "footer_running_version" : "running validator v",
   "footer_github" : "view project on github",
   "footer_create_issue" : "log an issue with the team",
-  "footer_download_cli" : "download the latest cli",
+  "footer_download_cli" : "download this app as a CLI tool",
   "footer_doc" : "view the validator documentation",
   "footer_openapi" : "view the OpenAPI documentation",
   "validation_results" : "Results",

--- a/src/commonMain/resources/static-content/polyglot/es.json
+++ b/src/commonMain/resources/static-content/polyglot/es.json
@@ -79,7 +79,7 @@
     "footer_running_version": "corriendo validador v",
     "footer_github": "ver proyecto en github",
     "footer_create_issue": "registrar un problema con el equipo",
-    "footer_download_cli": "descargar la ultima versión de linea de comandos",
+    "footer_download_cli": "descargar esta aplicación como una linea de comandos",
     "footer_doc": "ver la documentación del validador",
     "footer_openapi" : "ver la documentación del OpenAPI",
     "validation_results": "Resultados",


### PR DESCRIPTION
"download the latest cli" is ambiguous, and has been interpreted by some users to mean the org.hl7.fhir.core validator CLI. 

This updates the text to indicate this app, instead of an unspecified CLI.