### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/src/commonMain/resources/static-content/openapi.yml
+++ b/src/commonMain/resources/static-content/openapi.yml
@@ -184,6 +184,41 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/packageServerStatus"
+  /health/ready:
+    get:
+      tags:
+        - Health
+      description: "Readiness probe. Returns 200 OK if all presets have been loaded and the validation service is ready, otherwise returns 503."
+      operationId: healthReady
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: OK
+        "503":
+          description: Service Unavailable
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ValidationService not ready
+  /health/live:
+    get:
+      tags:
+        - Health
+      description: "Liveness probe. Always returns OK if the service is running."
+      operationId: healthLive
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: OK
 
 
 components:

--- a/src/jvmMain/kotlin/Module.kt
+++ b/src/jvmMain/kotlin/Module.kt
@@ -1,5 +1,6 @@
 import io.ktor.serialization.gson.*
 import controller.debug.debugModule
+import controller.health.healthModule
 import controller.ig.igModule
 import controller.terminology.terminologyModule
 import controller.uptime.uptimeModule
@@ -96,6 +97,7 @@ fun Application.setup() {
         validationModule()
         terminologyModule()
         uptimeModule()
+        healthModule()
 
         get("/") {
             call.respondText(

--- a/src/jvmMain/kotlin/controller/health/HealthModule.kt
+++ b/src/jvmMain/kotlin/controller/health/HealthModule.kt
@@ -1,0 +1,25 @@
+package controller.health
+
+import controller.validation.ValidationServiceStatus
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.http.*
+
+fun Route.healthModule() {
+    route("/health/ready") {
+        get {
+            if (ValidationServiceStatus.isReady()) {
+                call.respond(HttpStatusCode.OK, "OK")
+            } else {
+                call.respond(HttpStatusCode.ServiceUnavailable, "ValidationService not ready")
+            }
+        }
+    }
+
+    route("/health/live") {
+        get {
+            call.respond(HttpStatusCode.OK, "OK")
+        }
+    }
+}

--- a/src/jvmMain/kotlin/controller/validation/ValidationServiceFactoryImpl.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationServiceFactoryImpl.kt
@@ -30,18 +30,19 @@ class ValidationServiceFactoryImpl : ValidationServiceFactory {
         val validationService =
             ValidationService(sessionCache);
         thread {
-        presets.forEach {
-            if (it.key != "CUSTOM") {
-                println("Loading preset: " + it.key)
-                try {
-                    validationService.putBaseEngine(it.key, it.validationContext)
-                } catch (e: Exception) {
-                    println("Error loading preset: " + it.key)
-                    e.printStackTrace()
+            presets.forEach {
+                if (it.key != "CUSTOM") {
+                    println("Loading preset: " + it.key)
+                    try {
+                        validationService.putBaseEngine(it.key, it.validationContext)
+                    } catch (e: Exception) {
+                        println("Error loading preset: " + it.key)
+                        e.printStackTrace()
+                    }
+                    println("Preset loaded: " + it.key);
                 }
-                println("Preset loaded: " + it.key);
             }
-        }
+            ValidationServiceStatus.setService(validationService)
         }
         return validationService
     }
@@ -71,7 +72,7 @@ class ValidationServiceFactoryImpl : ValidationServiceFactory {
         return Collections.unmodifiableList(presets)
     }
 
-    override fun getValidationService() : ValidationService {
+    override fun getValidationService(): ValidationService {
         if (java.lang.Runtime.getRuntime().freeMemory() < validationServiceConfig.engineReloadThreshold) {
             println(
                 "Free memory ${

--- a/src/jvmMain/kotlin/controller/validation/ValidationServiceStatus.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationServiceStatus.kt
@@ -1,0 +1,14 @@
+package controller.validation
+
+import org.hl7.fhir.validation.service.ValidationService
+import java.util.concurrent.atomic.AtomicReference
+
+object ValidationServiceStatus {
+    private val serviceRef = AtomicReference<ValidationService?>(null)
+
+    fun setService(service: ValidationService) {
+        serviceRef.set(service)
+    }
+
+    fun isReady(): Boolean = serviceRef.get() != null
+}


### PR DESCRIPTION
This pull request introduces health check endpoints to the service, allowing readiness and liveness probes for deployment and monitoring purposes. The service is considered ready only after all presets are loaded.

**Health check endpoints and readiness tracking:**

* Implemented `HealthModule.kt` with routes for `/health/ready` (returns 200 if validation service is ready, 503 otherwise) and `/health/live` (always returns 200 if service is running).
* Added `/health/ready` and `/health/live` endpoints to the OpenAPI specification in `openapi.yml`, documenting their responses and intended use for readiness and liveness probes.

**Validation service readiness management:**

* Added `ValidationServiceStatus.kt` to track the readiness of the validation service using an atomic reference, with methods to set the service and check readiness.
* Updated `ValidationServiceFactoryImpl.kt` to set the validation service in `ValidationServiceStatus` after presets are loaded, ensuring readiness is accurately reported.