### PR TITLE
fix: prevent unbounded memory leak during concurrent validation under…

### DIFF
--- a/src/jvmMain/kotlin/controller/validation/ValidationServiceFactoryImpl.kt
+++ b/src/jvmMain/kotlin/controller/validation/ValidationServiceFactoryImpl.kt
@@ -16,12 +16,18 @@ import kotlin.collections.ArrayList
 class ValidationServiceFactoryImpl : ValidationServiceFactory {
     private val validationServiceConfig: ValidationServiceConfig = ValidatorApplicationConfig.validationServiceConfig
     private var sessionCacheFactory: SessionCacheFactory = SessionCacheFactoryImpl()
+    @Volatile
     private var validationService: ValidationService
     private var presets: List<Preset>
+
+    private val reloadLock = java.util.concurrent.locks.ReentrantLock()
+    private var lastReloadTime: Long = 0
+    private val RELOAD_COOLDOWN_MS = java.util.concurrent.TimeUnit.MINUTES.toMillis(5)
 
     init {
         presets = loadPresets();
         validationService = createValidationServiceInstance();
+        lastReloadTime = System.currentTimeMillis()
     }
 
     private fun createValidationServiceInstance(): ValidationService {
@@ -72,13 +78,30 @@ class ValidationServiceFactoryImpl : ValidationServiceFactory {
     }
 
     override fun getValidationService() : ValidationService {
-        if (java.lang.Runtime.getRuntime().freeMemory() < validationServiceConfig.engineReloadThreshold) {
-            println(
-                "Free memory ${
-                    java.lang.Runtime.getRuntime().freeMemory()
-                } is less than ${validationServiceConfig.engineReloadThreshold}. Re-initializing validationService"
-            );
-            validationService = createValidationServiceInstance();
+        val freeMemory = java.lang.Runtime.getRuntime().freeMemory()
+        if (freeMemory < validationServiceConfig.engineReloadThreshold) {
+            val now = System.currentTimeMillis()
+            // Try to acquire lock. If we can't, another thread is already reloading it, so just return the existing one.
+            if (reloadLock.tryLock()) {
+                try {
+                    // Double check time and memory inside the lock
+                    if (java.lang.Runtime.getRuntime().freeMemory() < validationServiceConfig.engineReloadThreshold &&
+                        (now - lastReloadTime) > RELOAD_COOLDOWN_MS) {
+                        
+                        println(
+                            "Free memory ${
+                                java.lang.Runtime.getRuntime().freeMemory()
+                            } is less than ${validationServiceConfig.engineReloadThreshold} and cooldown passed. Re-initializing validationService"
+                        );
+                        validationService = createValidationServiceInstance();
+                        lastReloadTime = System.currentTimeMillis()
+                    }
+                } finally {
+                    reloadLock.unlock()
+                }
+            } else {
+                println("Memory is low ($freeMemory), but another thread is currently re-initializing the engine. Skipping.")
+            }
         }
         return validationService;
     }


### PR DESCRIPTION
This PR fixes a memory and thread exhaustion vulnerability in `ValidationServiceFactoryImpl.kt`.

Under high concurrency, if the JVM's free memory dips below the `engineReloadThreshold`, the `getValidationService()` method re-initializes `ValidationService`. Because this check was not synchronized, a burst of incoming validation requests during a low-memory state would all evaluate the condition as `true` simultaneously. 

This resulted in an unbounded loop where the application spawned dozens of massive `ValidationEngine` instances and hundreds of detached background downloader threads to reload presets. The JVM quickly spiraled into maxed CPU usage, gigabytes of leaked memory, and eventual crashes.

### **Impact & Context**
We discovered this in while utilizing the validator API in conjunction with [au-fhir-inferno](https://github.com/hl7au/au-fhir-inferno). Under heavy testing load, the validator-wrapper would hit the memory threshold and trigger this un-synchronized cache reset. The true impact was three-fold:
1. **Severe API Latency**: The heavy I/O of re-building the cache blocks threads for several seconds. When 5 requests initialize 5 engines simultaneously, the CPU maxes out and all incoming requests hang, causing massive latency spikes (5-20s+) and upstream application timeouts.
2. **Caching "Thrashing"**: Under load, if the threshold is reached frequently, the server spins up a death spiral of actively deleting and downloading large FHIR packages, completely negating the benefit of an in-memory cache.
3. **Thread, File & Network Exhaustion**: Even if the environment's memory can survive the spike, the background threads consume vast network bandwidth pulling `.tgz` files from `packages.fhir.org` and leak file descriptors on the host container.

### **Changes**
*   Applied `@Volatile` to `validationService`.
*   Added a `ReentrantLock` (`reloadLock`) to ensure only one thread can lock and initialize the cache.
*   Added a 5-minute cooldown (`RELOAD_COOLDOWN_MS`) so the engine isn't perpetually thrashed under sustained heavy load.
*   Concurrent threads that hit the low memory state while the lock is acquired will now safely log and skip initialization, returning the existing engine and preventing the death spiral.
