### PR TITLE
Update org.hl7.fhir.core to 6.9.7

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+* Update org.hl7.fhir.core to 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1 +1,2 @@
-* Update org.hl7.fhir.core to 
+* Update org.hl7.fhir.core to 6.9.7
+* Fix link resolution when running in a path

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.js.compiler=ir
 kotlin.daemon.jvmargs=-Xmx2048m
 
 # versions
-fhirCoreVersion= 6.9.4
+fhirCoreVersion= 6.9.7
 
 junitVersion=5.9.3
 mockk_version=1.13.5

--- a/http-client-tests/tests/explicit-queries.http
+++ b/http-client-tests/tests/explicit-queries.http
@@ -112,7 +112,7 @@ Content-Type: application/json
     client.test("Issues are Correct", function() {
         let issues = response.body.outcomes[0].issues
         client.log("issues:" + issues.length)
-        client.assert(issues.length === 67);
+        client.assert(issues.length === 63);
         client.assert(containsIssue(issues, 2, 37, "The Snomed CT code 373270004 (Penicillin -class of antibiotic- (substance)) is not a member of the IPS free set", "BUSINESSRULE", "INFORMATION"))
         client.assert(containsIssue(issues, 144, 28, "This element does not match any known slice defined in the profile http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-composition|1.0.0-ci-build (this may not be a problem, but you should check that it's not intended to match a slice)", "INFORMATIONAL", "INFORMATION"))
     });

--- a/http-client-tests/tests/preset-queries.http
+++ b/http-client-tests/tests/preset-queries.http
@@ -85,7 +85,7 @@ Content-Type: application/json
     client.test("Issues are Correct", function() {
         let issues = response.body.outcomes[0].issues
         client.log("issues:" + issues.length)
-        client.assert(issues.length === 53);
+        client.assert(issues.length === 52);
         client.assert(containsIssue(issues, 1, 2, "The Snomed CT code 764146007 (Penicillin (substance)) is not a member of the IPS free set", "BUSINESSRULE", "INFORMATION"))
         client.assert(containsIssue(issues, 1, 2, "The Snomed CT code 108774000 (Anastrozole) is not a member of the IPS free set", "BUSINESSRULE", "INFORMATION"))
 
@@ -110,7 +110,7 @@ Content-Type: application/json
     client.test("Issues are Correct", function() {
         let issues = response.body.outcomes[0].issues
         client.log("issues:" + issues.length)
-        client.assert(issues.length === 75);
+        client.assert(issues.length === 63);
         client.assert(containsIssue(issues, 2, 37, "The Snomed CT code 373270004 (Penicillin -class of antibiotic- (substance)) is not a member of the IPS free set", "BUSINESSRULE", "INFORMATION"))
         client.assert(containsIssue(issues, 144, 28, "This element does not match any known slice defined in the profile http://hl7.org.au/fhir/ps/StructureDefinition/au-ps-composition|1.0.0-ci-build (this may not be a problem, but you should check that it's not intended to match a slice)", "INFORMATIONAL", "INFORMATION"))
     });

--- a/src/jsMain/kotlin/api/Client.kt
+++ b/src/jsMain/kotlin/api/Client.kt
@@ -1,16 +1,13 @@
 package api
 
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
-import io.ktor.client.plugins.kotlinx.serializer.*
 import web.location.location
 import kotlinx.serialization.json.*
 
 
-val endpoint = location.origin + "/" // only needed until https://github.com/ktorio/ktor/issues/1695 is resolved
+val endpoint = location.href + "/" // only needed until https://github.com/ktorio/ktor/issues/1695 is resolved
 
 val jsonClient = HttpClient (){
     install(ContentNegotiation) {


### PR DESCRIPTION
This also contains a link resolution fix when installed using a path instead of '/' on a sever.