### PR TITLE
Fix tx.fhir.org terminology cache compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.js.compiler=ir
 kotlin.daemon.jvmargs=-Xmx2048m
 
 # versions
-fhirCoreVersion= 6.9.7
+fhirCoreVersion= 6.9.11
 
 junitVersion=5.9.3
 mockk_version=1.13.5
@@ -40,4 +40,3 @@ jacksonVersion=2.15.0
 koinVersion=3.4.0
 logbackVersion=1.5.3
 kmongoVersion=4.5.0
-

--- a/src/jvmMain/kotlin/Server.kt
+++ b/src/jvmMain/kotlin/Server.kt
@@ -3,6 +3,7 @@ import controller.ControllersInjection
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.jetty.*
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientContext
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
 import utils.PackageCacheDownloaderRunnable
@@ -37,8 +38,13 @@ var runningAsDesktopStandalone: Boolean = false
  * takes priority, and the desktop version will not be booted.
  */
 fun main(args: Array<String>) {
+    configureTerminologyClientCaching()
     runningAsDesktopStandalone = runningAsDesktopApp(args)
     startServer(args)
+}
+
+internal fun configureTerminologyClientCaching() {
+    TerminologyClientContext.setCanUseCacheId(true)
 }
 
 fun startServer(args: Array<String>) {
@@ -80,6 +86,5 @@ fun stopServer() {
 private fun runningAsDesktopApp(args: Array<String>): Boolean {
     return args.isNotEmpty() && args.contains(LOCAL_APP_FLAG) && !args.contains(FULL_STACK_FLAG)
 }
-
 
 

--- a/src/jvmTest/kotlin/TerminologyCachingTest.kt
+++ b/src/jvmTest/kotlin/TerminologyCachingTest.kt
@@ -1,0 +1,21 @@
+import org.hl7.fhir.r5.terminologies.client.TerminologyClientContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+class TerminologyCachingTest {
+
+    @AfterEach
+    fun resetTerminologyClientCaching() {
+        TerminologyClientContext.setCanUseCacheId(false)
+    }
+
+    @Test
+    fun `terminology client caching is enabled during application startup`() {
+        TerminologyClientContext.setCanUseCacheId(false)
+
+        configureTerminologyClientCaching()
+
+        assertTrue(TerminologyClientContext.isCanUseCacheId())
+    }
+}


### PR DESCRIPTION
## Summary

After tx.fhir.org changed its caching protocol, test kits running with terminology validation enabled would have their validation requests stall and eventually time out. Test kits with the terminology server disabled were unaffected.

This PR:

- Upgrades `org.hl7.fhir.core` from 6.9.7 to 6.9.11.
- Enables server-side terminology caching before validation engines are created.
- Adds a focused JVM test for the startup configuration.

## Why this is needed

tx.fhir.org now uses a server-managed terminology-cache protocol.

Older FHIR Core clients generated arbitrary `cache-id` values and sent them as operation parameters. The updated terminology server only accepts cache identifiers it created through `$cache-control`. Unknown or expired identifiers are rejected with a coded `cache-id-unknown` response.

FHIR Core 6.9.11 implements the new protocol:

1. Detect whether the server advertises `$cache-control`.
2. Call `$cache-control` to start a cache.
3. Receive a server-issued cache identifier.
4. Send that identifier as the `X-Cache-Id` HTTP header.
5. Stop generating or sending arbitrary cache IDs as operation parameters.

The wrapper must also enable this behavior globally with:

`TerminologyClientContext.setCanUseCacheId(true)`

This matches the official validator CLI and must happen before validation engines are created.

Without this update, terminology-heavy validations can encounter unknown-cache responses, excessive terminology processing, `TerminologyServiceProtectionException`, and HTTP request timeouts.

## Related upstream changes

### tx.fhir.org server

The live [tx.fhir.org R4 CapabilityStatement](https://tx.fhir.org/r4/metadata?_summary=true) identifies FHIRsmith as the server and advertises `$cache-control`.

Relevant server changes:

- [FHIRsmith PR #259 — Rebuild how caching works](https://github.com/HealthIntersections/FHIRsmith/pull/259)
  - [Commit `eb5d952`](https://github.com/HealthIntersections/FHIRsmith/commit/eb5d952edff67734c5950f78bb402211affd2564)
  - Introduced `$cache-control`, server-issued cache identifiers, `X-Cache-Id`, and explicit `cache-id-unknown` responses.

- [FHIRsmith PR #260 — Fix cache-control header handling](https://github.com/HealthIntersections/FHIRsmith/pull/260)
  - [Commit `423a999`](https://github.com/HealthIntersections/FHIRsmith/commit/423a99928ff21b5a5297ed74dca881973f438e0f)
  - Ensured `X-Cache-Id` works consistently across `$expand`, `$lookup`, `$validate-code`, batch validation, and related operations.

### FHIR Core client

The matching client implementation was introduced in:

- [org.hl7.fhir.core PR #2483 — Rework terminology caching](https://github.com/hapifhir/org.hl7.fhir.core/pull/2483)
  - [Commit `353d61a`](https://github.com/hapifhir/org.hl7.fhir.core/commit/353d61a14fe0ce8d79ef867b4d19b855560971a1): implements `$cache-control` negotiation and `X-Cache-Id`.
  - [Commit `a59a35f`](https://github.com/hapifhir/org.hl7.fhir.core/commit/a59a35f276b1d426daa6fdffe782a9597fdd65ab): aligns cache-control modes and client behavior.
  - [Commit `25af8d4`](https://github.com/hapifhir/org.hl7.fhir.core/commit/25af8d4fae8b26bf7139287aa3f3da73083706fa): enables caching in the official validator CLI.
  - [Commit `2eba1ba`](https://github.com/hapifhir/org.hl7.fhir.core/commit/2eba1ba52b4165b360c66fe007dae300a0718e05): removes the randomly generated client cache ID rejected by upgraded servers.

## Compatibility

The REST API and request/response formats remain unchanged.

This change does not modify:

- Proxy handling
- IG mounting
- Session-cache sizing or eviction
- Health-check endpoints
- Engine-reload behavior

The wrapper does not generate, store, or manually send cache identifiers. That lifecycle remains managed by FHIR Core and the terminology server.

## Verification

- `./gradlew jvmTest`: 42 tests passed with zero failures.
- The new terminology-caching startup test passed.
- `/validator/version` reported validator core 6.9.11.
- Default validation completed twice with HTTP 200.
- IPS validation completed twice with HTTP 200.
- No unknown-cache errors, terminology protection exceptions, or request timeouts were observed.