### PR TITLE
Honor proxy settings in wrapper HTTP clients

### DIFF
--- a/src/jvmMain/kotlin/api/HttpClientProxyConfig.kt
+++ b/src/jvmMain/kotlin/api/HttpClientProxyConfig.kt
@@ -1,0 +1,21 @@
+package api
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.engine.cio.*
+import io.ktor.http.*
+
+internal fun resolveHttpClientProxyUrl(environment: Map<String, String> = System.getenv()): String? {
+    return listOf("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
+        .firstNotNullOfOrNull { key -> environment[key]?.trim()?.takeIf { it.isNotEmpty() } }
+}
+
+internal fun HttpClientConfig<CIOEngineConfig>.configureProxyFromEnvironment(
+    environment: Map<String, String> = System.getenv()
+) {
+    resolveHttpClientProxyUrl(environment)?.let { proxyUrl ->
+        engine {
+            proxy = ProxyBuilder.http(Url(proxyUrl))
+        }
+    }
+}

--- a/src/jvmMain/kotlin/api/HttpClientProxyConfig.kt
+++ b/src/jvmMain/kotlin/api/HttpClientProxyConfig.kt
@@ -4,10 +4,35 @@ import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.http.*
+import java.net.URI
+import java.net.URISyntaxException
 
 internal fun resolveHttpClientProxyUrl(environment: Map<String, String> = System.getenv()): String? {
     return listOf("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
         .firstNotNullOfOrNull { key -> environment[key]?.trim()?.takeIf { it.isNotEmpty() } }
+}
+
+internal fun parseHttpClientProxyUrl(proxyUrl: String): Url {
+    val uri = try {
+        URI(proxyUrl)
+    } catch (_: URISyntaxException) {
+        throw IllegalArgumentException("Configured HTTP proxy URL is malformed")
+    }
+
+    require(uri.scheme.equals("http", ignoreCase = true) || uri.scheme.equals("https", ignoreCase = true)) {
+        "Configured HTTP proxy must use the http or https scheme"
+    }
+    require(!uri.host.isNullOrBlank()) {
+        "Configured HTTP proxy must include a hostname"
+    }
+
+    val url = try {
+        Url(proxyUrl)
+    } catch (_: URLParserException) {
+        throw IllegalArgumentException("Configured HTTP proxy URL is malformed")
+    }
+
+    return url
 }
 
 internal fun HttpClientConfig<CIOEngineConfig>.configureProxyFromEnvironment(
@@ -15,7 +40,7 @@ internal fun HttpClientConfig<CIOEngineConfig>.configureProxyFromEnvironment(
 ) {
     resolveHttpClientProxyUrl(environment)?.let { proxyUrl ->
         engine {
-            proxy = ProxyBuilder.http(Url(proxyUrl))
+            proxy = ProxyBuilder.http(parseHttpClientProxyUrl(proxyUrl))
         }
     }
 }

--- a/src/jvmMain/kotlin/api/terminogy/TerminologyApiImpl.kt
+++ b/src/jvmMain/kotlin/api/terminogy/TerminologyApiImpl.kt
@@ -1,5 +1,6 @@
 package api.terminogy
 
+import api.configureProxyFromEnvironment
 import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -17,6 +18,7 @@ const val CONFORMANCE_ENDPOINT = "metadata?_summary=true"
 class TerminologyApiImpl : TerminologyApi {
 
     private val client = HttpClient(CIO) {
+        configureProxyFromEnvironment()
         configureJson()
         configureLogging()
     }

--- a/src/jvmMain/kotlin/api/uptime/EndpointApiImpl.kt
+++ b/src/jvmMain/kotlin/api/uptime/EndpointApiImpl.kt
@@ -3,19 +3,31 @@ package api.uptime
 import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.http.*
 import io.ktor.serialization.jackson.*
 
 const val ENDPOINT_API_TIMEOUT: Long = 10000;
 
+internal fun resolveEndpointProxyUrl(environment: Map<String, String> = System.getenv()): String? {
+    return listOf("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
+        .firstNotNullOfOrNull { key -> environment[key]?.trim()?.takeIf { it.isNotEmpty() } }
+}
+
 class EndpointApiImpl : EndpointApi {
 
     private val client = HttpClient (CIO) {
+        resolveEndpointProxyUrl()?.let { proxyUrl ->
+            engine {
+                proxy = ProxyBuilder.http(Url(proxyUrl))
+            }
+        }
         configureJson()
         configureLogging()
         configureTimeout()

--- a/src/jvmMain/kotlin/api/uptime/EndpointApiImpl.kt
+++ b/src/jvmMain/kotlin/api/uptime/EndpointApiImpl.kt
@@ -1,33 +1,23 @@
 package api.uptime
 
+import api.configureProxyFromEnvironment
 import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.client.engine.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 
 import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.http.*
 import io.ktor.serialization.jackson.*
 
 const val ENDPOINT_API_TIMEOUT: Long = 10000;
 
-internal fun resolveEndpointProxyUrl(environment: Map<String, String> = System.getenv()): String? {
-    return listOf("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
-        .firstNotNullOfOrNull { key -> environment[key]?.trim()?.takeIf { it.isNotEmpty() } }
-}
-
 class EndpointApiImpl : EndpointApi {
 
     private val client = HttpClient (CIO) {
-        resolveEndpointProxyUrl()?.let { proxyUrl ->
-            engine {
-                proxy = ProxyBuilder.http(Url(proxyUrl))
-            }
-        }
+        configureProxyFromEnvironment()
         configureJson()
         configureLogging()
         configureTimeout()

--- a/src/jvmMain/kotlin/controller/terminology/TerminologyModule.kt
+++ b/src/jvmMain/kotlin/controller/terminology/TerminologyModule.kt
@@ -31,18 +31,16 @@ fun Route.terminologyModule() {
                         request.url))
                 )
             )
-        } catch (exception: ClientRequestException) {
-            call.respond(HttpStatusCode.OK, TerminologyServerResponse(
-                url = request.url,
-                validTxServer = false,
-                details = exception.localizedMessage)
-            )
-        } catch (exception: IOException) {
-            call.respond(HttpStatusCode.OK, TerminologyServerResponse(
-                url = request.url,
-                validTxServer = false,
-                details = exception.localizedMessage)
-            )
+        } catch (exception: Exception) {
+            when (exception) {
+                is ClientRequestException,
+                is IOException -> call.respond(HttpStatusCode.OK, TerminologyServerResponse(
+                    url = request.url,
+                    validTxServer = false,
+                    details = exception.localizedMessage)
+                )
+                else -> throw exception
+            }
         }
     }
 }// https://r4.ontoserver.csiro.au/fhir/

--- a/src/jvmMain/kotlin/controller/terminology/TerminologyModule.kt
+++ b/src/jvmMain/kotlin/controller/terminology/TerminologyModule.kt
@@ -12,6 +12,7 @@ import io.ktor.server.routing.*
 import model.TerminologyServerRequest
 import model.TerminologyServerResponse
 import org.koin.ktor.ext.inject
+import java.io.IOException
 
 fun Route.terminologyModule() {
 
@@ -31,6 +32,12 @@ fun Route.terminologyModule() {
                 )
             )
         } catch (exception: ClientRequestException) {
+            call.respond(HttpStatusCode.OK, TerminologyServerResponse(
+                url = request.url,
+                validTxServer = false,
+                details = exception.localizedMessage)
+            )
+        } catch (exception: IOException) {
             call.respond(HttpStatusCode.OK, TerminologyServerResponse(
                 url = request.url,
                 validTxServer = false,

--- a/src/jvmTest/kotlin/api/HttpClientProxyConfigTest.kt
+++ b/src/jvmTest/kotlin/api/HttpClientProxyConfigTest.kt
@@ -1,6 +1,8 @@
 package api
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -9,26 +11,25 @@ import kotlin.test.assertNull
 class HttpClientProxyConfigTest {
 
     @Test
-    fun `uses the configured HTTP proxy`() {
+    fun `prefers uppercase HTTP proxy when multiple proxy variables are configured`() {
         val proxyUrl = resolveHttpClientProxyUrl(
             mapOf(
                 "HTTP_PROXY" to "http://proxy.example:8080",
-                "HTTPS_PROXY" to "http://secure-proxy.example:8080"
+                "http_proxy" to "http://lowercase-proxy.example:8080",
+                "HTTPS_PROXY" to "http://secure-proxy.example:8080",
+                "https_proxy" to "http://secure-lowercase-proxy.example:8080"
             )
         )
 
         assertEquals("http://proxy.example:8080", proxyUrl)
     }
 
-    @Test
-    fun `supports lowercase and HTTPS proxy fallbacks`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"])
+    fun `supports all proxy environment variable names`(variableName: String) {
         assertEquals(
-            "http://lowercase-proxy.example:8080",
-            resolveHttpClientProxyUrl(mapOf("http_proxy" to "http://lowercase-proxy.example:8080"))
-        )
-        assertEquals(
-            "http://secure-proxy.example:8080",
-            resolveHttpClientProxyUrl(mapOf("HTTPS_PROXY" to "http://secure-proxy.example:8080"))
+            "http://proxy.example:8080",
+            resolveHttpClientProxyUrl(mapOf(variableName to "http://proxy.example:8080"))
         )
     }
 

--- a/src/jvmTest/kotlin/api/HttpClientProxyConfigTest.kt
+++ b/src/jvmTest/kotlin/api/HttpClientProxyConfigTest.kt
@@ -1,14 +1,14 @@
-package api.uptime
+package api
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class EndpointApiImplTest {
+class HttpClientProxyConfigTest {
 
     @Test
     fun `uses the configured HTTP proxy`() {
-        val proxyUrl = resolveEndpointProxyUrl(
+        val proxyUrl = resolveHttpClientProxyUrl(
             mapOf(
                 "HTTP_PROXY" to "http://proxy.example:8080",
                 "HTTPS_PROXY" to "http://secure-proxy.example:8080"
@@ -22,17 +22,17 @@ class EndpointApiImplTest {
     fun `supports lowercase and HTTPS proxy fallbacks`() {
         assertEquals(
             "http://lowercase-proxy.example:8080",
-            resolveEndpointProxyUrl(mapOf("http_proxy" to "http://lowercase-proxy.example:8080"))
+            resolveHttpClientProxyUrl(mapOf("http_proxy" to "http://lowercase-proxy.example:8080"))
         )
         assertEquals(
             "http://secure-proxy.example:8080",
-            resolveEndpointProxyUrl(mapOf("HTTPS_PROXY" to "http://secure-proxy.example:8080"))
+            resolveHttpClientProxyUrl(mapOf("HTTPS_PROXY" to "http://secure-proxy.example:8080"))
         )
     }
 
     @Test
     fun `does not configure a proxy when variables are missing or blank`() {
-        assertNull(resolveEndpointProxyUrl(emptyMap()))
-        assertNull(resolveEndpointProxyUrl(mapOf("HTTP_PROXY" to "  ")))
+        assertNull(resolveHttpClientProxyUrl(emptyMap()))
+        assertNull(resolveHttpClientProxyUrl(mapOf("HTTP_PROXY" to "  ")))
     }
 }

--- a/src/jvmTest/kotlin/api/HttpClientProxyConfigTest.kt
+++ b/src/jvmTest/kotlin/api/HttpClientProxyConfigTest.kt
@@ -2,6 +2,8 @@ package api
 
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class HttpClientProxyConfigTest {
@@ -34,5 +36,34 @@ class HttpClientProxyConfigTest {
     fun `does not configure a proxy when variables are missing or blank`() {
         assertNull(resolveHttpClientProxyUrl(emptyMap()))
         assertNull(resolveHttpClientProxyUrl(mapOf("HTTP_PROXY" to "  ")))
+    }
+
+    @Test
+    fun `rejects malformed proxy URLs without exposing their value`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            parseHttpClientProxyUrl("http://user:secret@[invalid")
+        }
+
+        assertEquals("Configured HTTP proxy URL is malformed", exception.message)
+        assertFalse(exception.message.orEmpty().contains("secret"))
+        assertNull(exception.cause)
+    }
+
+    @Test
+    fun `rejects proxy URLs with unsupported schemes`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            parseHttpClientProxyUrl("socks://proxy.example:1080")
+        }
+
+        assertEquals("Configured HTTP proxy must use the http or https scheme", exception.message)
+    }
+
+    @Test
+    fun `rejects proxy URLs without a hostname`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            parseHttpClientProxyUrl("http:///proxy")
+        }
+
+        assertEquals("Configured HTTP proxy must include a hostname", exception.message)
     }
 }

--- a/src/jvmTest/kotlin/api/uptime/EndpointApiImplTest.kt
+++ b/src/jvmTest/kotlin/api/uptime/EndpointApiImplTest.kt
@@ -1,0 +1,38 @@
+package api.uptime
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EndpointApiImplTest {
+
+    @Test
+    fun `uses the configured HTTP proxy`() {
+        val proxyUrl = resolveEndpointProxyUrl(
+            mapOf(
+                "HTTP_PROXY" to "http://proxy.example:8080",
+                "HTTPS_PROXY" to "http://secure-proxy.example:8080"
+            )
+        )
+
+        assertEquals("http://proxy.example:8080", proxyUrl)
+    }
+
+    @Test
+    fun `supports lowercase and HTTPS proxy fallbacks`() {
+        assertEquals(
+            "http://lowercase-proxy.example:8080",
+            resolveEndpointProxyUrl(mapOf("http_proxy" to "http://lowercase-proxy.example:8080"))
+        )
+        assertEquals(
+            "http://secure-proxy.example:8080",
+            resolveEndpointProxyUrl(mapOf("HTTPS_PROXY" to "http://secure-proxy.example:8080"))
+        )
+    }
+
+    @Test
+    fun `does not configure a proxy when variables are missing or blank`() {
+        assertNull(resolveEndpointProxyUrl(emptyMap()))
+        assertNull(resolveEndpointProxyUrl(mapOf("HTTP_PROXY" to "  ")))
+    }
+}

--- a/src/jvmTest/kotlin/routing/terminology/TerminologyRoutingTest.kt
+++ b/src/jvmTest/kotlin/routing/terminology/TerminologyRoutingTest.kt
@@ -7,6 +7,7 @@ import controller.terminology.terminologyModule
 import instrumentation.TerminologyInstrumentation.givenATerminologyServerUrl
 import instrumentation.TerminologyInstrumentation.givenAValidCapabilityStatement
 import instrumentation.TerminologyInstrumentation.givenAnInvalidCapabilityStatement
+import io.ktor.client.network.sockets.ConnectTimeoutException
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.routing.*
@@ -70,5 +71,25 @@ class TerminologyRoutingTest: BaseRoutingTest() {
         val responseBody = response.parseBody(TerminologyServerResponse::class.java)
         Assertions.assertEquals(url, responseBody.url)
         Assertions.assertEquals(false, responseBody.validTxServer)
+    }
+
+    @Test
+    fun `when terminology server connection times out, response with invalid terminology is returned`() =
+    withBaseTestApplication {
+        val url = givenATerminologyServerUrl()
+        val terminologyServerRequest = TerminologyServerRequest(url = url)
+        coEvery { terminologyApi.getCapabilityStatement(any()) } throws
+            ConnectTimeoutException("Connect timeout", null)
+
+        val response = client.post(TERMINOLOGY_ENDPOINT) {
+            contentType(ContentType.Application.Json)
+            setBody(toJsonBody(terminologyServerRequest))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val responseBody = response.parseBody(TerminologyServerResponse::class.java)
+        Assertions.assertEquals(url, responseBody.url)
+        Assertions.assertEquals(false, responseBody.validTxServer)
+        Assertions.assertEquals("Connect timeout", responseBody.details)
     }
 }


### PR DESCRIPTION
## Summary

Configure the wrapper-owned Ktor HTTP clients to use the proxy settings already provided through the container environment.

The same shared proxy configuration is now used by:

- `EndpointApiImpl`, which supports `/txStatus` and `/packStatus`
- `TerminologyApiImpl`, which supports `POST /terminology`

## Problem

In environments where direct outbound connections are restricted, the container had `HTTP_PROXY` and `HTTPS_PROXY` configured, but the Ktor CIO clients did not explicitly use them.

This caused:

- The tx.fhir.org status check to time out.
- The packages.fhir.org status check to time out.
- The UI status checks to take approximately ten seconds because they run sequentially.
- Terminology-server verification to time out even though tx.fhir.org was reachable through the configured proxy.
- `POST /terminology` to return HTTP 500 for a connection timeout.

Example errors:

```text
ConnectTimeoutException: Connect timeout has expired
[url=http://tx.fhir.org/icon-fhir-16.png]

ConnectTimeoutException: Connect timeout has expired
[url=https://tx.fhir.org/r4/metadata?_summary=true]
```

## Changes

- Added a shared `configureProxyFromEnvironment()` function for Ktor CIO clients.
- Resolve proxy configuration from:
  - `HTTP_PROXY`
  - `http_proxy`
  - `HTTPS_PROXY`
  - `https_proxy`
- Preserve direct connections when no proxy variable is configured.
- Apply the shared configuration to both `EndpointApiImpl` and `TerminologyApiImpl`.
- Handle terminology-server connection failures as an invalid server response instead of an unhandled HTTP 500.

A failed terminology connection now returns HTTP 200 with:

```json
{
  "url": "https://tx.fhir.org/r4",
  "validTxServer": false,
  "details": "Connect timeout"
}
```

## Scope

This change affects only the wrapper-owned Ktor CIO clients.

It does not change:

- FHIR Core terminology-client behavior
- FHIR Core package loading
- Terminology caching
- Validation request or response formats
- Health-check endpoint formats
- Existing timeout values
- Session caching
- Generated version properties

## Testing

- Ran `./gradlew jvmTest`
- 46 tests passed with 0 failures
- Added focused tests covering:
  - Proxy-variable precedence
  - Lowercase proxy variables
  - HTTPS proxy fallback
  - Missing or blank proxy variables
  - Terminology connection timeout handling

Live external-service calls remain outside CI to avoid network and proxy-related flakiness.

CC: @dotasek 